### PR TITLE
Some fixes (missing Unicode unescaping)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,9 @@
             "name": "js-properties-to-json",
             "version": "0.1.0",
             "license": "MIT License",
-            "dependencies": {
-                "lodash-es": "^4.17.21"
-            },
             "devDependencies": {
                 "@rollup/plugin-node-resolve": "^15.0.2",
                 "@rollup/plugin-typescript": "^11.1.1",
-                "@types/lodash-es": "^4.17.6",
                 "@types/node": "^17.0.23",
                 "gh-pages": "^5.0.0",
                 "onchange": "^7.1.0",
@@ -114,21 +110,6 @@
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
             "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==",
             "dev": true
-        },
-        "node_modules/@types/lodash": {
-            "version": "4.14.194",
-            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.194.tgz",
-            "integrity": "sha512-r22s9tAS7imvBt2lyHC9B8AGwWnXaYb1tY09oyLkXDs4vArpYJzw09nj8MLx5VfciBPGIb+ZwG0ssYnEPJxn/g==",
-            "dev": true
-        },
-        "node_modules/@types/lodash-es": {
-            "version": "4.17.7",
-            "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.7.tgz",
-            "integrity": "sha512-z0ptr6UI10VlU6l5MYhGwS4mC8DZyYer2mCoyysZtSF7p26zOX8UpbrV0YpNYLGS8K4PUFIyEr62IMFFjveSiQ==",
-            "dev": true,
-            "dependencies": {
-                "@types/lodash": "*"
-            }
         },
         "node_modules/@types/node": {
             "version": "17.0.45",
@@ -1134,11 +1115,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/lodash-es": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-            "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
         },
         "node_modules/make-dir": {
             "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "devDependencies": {
         "@rollup/plugin-node-resolve": "^15.0.2",
         "@rollup/plugin-typescript": "^11.1.1",
-        "@types/lodash-es": "^4.17.6",
         "@types/node": "^17.0.23",
         "gh-pages": "^5.0.0",
         "onchange": "^7.1.0",
@@ -49,8 +48,5 @@
         "serve": "^14.2.0",
         "tslib": "^2.3.1",
         "typescript": "^5.0.4"
-    },
-    "dependencies": {
-        "lodash-es": "^4.17.21"
     }
 }

--- a/sample.properties
+++ b/sample.properties
@@ -4,6 +4,7 @@ complexObject.booleans.falseValue=false
 complexObject.numbers.integerValue=11
 complexObject.numbers.doubleValue=11.0
 complexObject.text=text
+complexObject.t\u0119\u015bt\ complex\u0020key=\\compl\u0119x\:value
 simpleText=text2
 complexObject.nullValue=null
 complexObject.empty=

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
-import isPlainObject from 'lodash-es/isPlainObject'
-import isArray from 'lodash-es/isArray';
+const isPlainObject = (o: any) => typeof o === "object" && o.__proto__ === Object.prototype;
+const isArray = Array.isArray;
 
 const defaultValue = (v: any, d: any) => (v === undefined ? d : v);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,11 +43,21 @@ const propertiesToJSON = (str: string, options = defaults) => {
             const key = colonifiedLine
                 // Extract key from index 0 to first not escaped colon index
                 .substring(0, colonifiedLine.search(/(?<!\\):/))
+                // Unescape Unicode
+                .replace(/\\u([0-9A-F]{4})/g, (s, u) => String.fromCharCode(parseInt(u, 16)))
                 // Remove not needed backslash from key
-                .replace(/\\/g, '')
+                .replace(/\\([^\\])/g, '$1')
+                .replace(/\\\\/g, '\\')
                 .trim();
 
-            let value = colonifiedLine.substring(colonifiedLine.search(/(?<!\\):/) + 1).trim() as string | number;
+            let value: string | number = colonifiedLine
+                .substring(colonifiedLine.search(/(?<!\\):/) + 1)
+                // Unescape Unicode
+                .replace(/\\u([0-9A-F]{4})/g, (s, u) => String.fromCharCode(parseInt(u, 16)))
+                // Remove not needed backslash from key
+                .replace(/\\([^\\])/g, '$1')
+                .replace(/\\\\/g, '\\')
+                .trim();
 
             if (parsedOptions.parseNumber && isNumeric(value)) {
                 value = +value;


### PR DESCRIPTION
Code:

```ts
const test = String.raw`
actorsRights.U\u017Cytkownicy\ publiczni\u0020v2=\\W\u0142adys\u0142aw\:rw
`;
console.log(propertiesToJSON(test, { convertToJsonTree: true }));
```

Expected:

```js
{
  actorsRights: {
    "Użytkownicy publiczni v2": "\\Władysław:rw",
  },
}
```

Actual:

```js
{
  "actorsRights": {
    "Uu017Cytkownicy publiczniu0020v2": "\\\\W\\u0142adys\\u0142aw\\:rw"
  }
}
```

Note: things like spaces can be escaped both with `\ ` and `\u0020`, whichever is used depends on the encoder or whether the source file was assembled manually to be parsable by Java.

Also removes REALLY unneeded dependency on lodash for simple checks, plus fixes TypeScript typings stuff.

---

Also I was in the middle of fixing TypeScript types, but stopped and gave up after realizing there's more bugs:

1. This triggers TypeError:
```
test[0]=haha
test[0].ohno=oops
```

2. This silently eats the first value:
```
test[0]=haha
test.ohno=oops
```
gives:
```js
  "test": {
    "ohno": "oops"
  }
```
whereas ideally it'd give:
```js
  "test": {
    "0": "haha",
    "ohno": "oops"
  }
```
(after some condition like `if (isArray(result_key)) result_key = { ...result_key } as object as NestedKeyValType`), but I burned out trying to dig into that, so welp, just something to keep in mind I guess